### PR TITLE
Update composer.json and tag a release package to show as stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,5 @@
         "psr-0": {
             "RocketShipIt": "src"
         }
-    },
-    "version": "1.0.0"    
+    }
 }


### PR DESCRIPTION
I had suggested the change I'm undoing here as a way to make packagist see this package as stable in a prior pull request. I think I was wrong based on this info https://getcomposer.org/doc/02-libraries.md#library-versioning , apologies for that error. Based on the "Managing package versions" section of this page https://packagist.org/about I believe if you could **complete both**
a) commit this change (as the tags mentioned next will instead dictate the version) 
and 
b) tag a release called 1.0.0 or a similar version notation you'd prefer
Packagist would see this package as stable. Thank you

More detailed reasoning for this change: As it stands, this package is not seen as meeting the "stable" definition for the minimum stability check in composer.json, although I assume it should be marked as such since it is feature complete. This means you now have to set "minimum-stability": "dev", in composer.json which means your other dependencies can possibly pull in packages that are not at the stable label, which is not ideal in production. Thanks